### PR TITLE
Extend add metadata

### DIFF
--- a/lib/paul_bunyan/metadata_logging.rb
+++ b/lib/paul_bunyan/metadata_logging.rb
@@ -8,6 +8,18 @@ module PaulBunyan
       formatter.with_metadata(metadata) { yield self }
     end
 
+    def add_metadata(metadata)
+      formatter.add_metadata(metadata)
+    end
+
+    def remove_metadata(metadata)
+      formatter.remove_metadata(metadata)
+    end
+
+    def current_metadata
+      formatter.current_metadata
+    end
+
     def flush
       clear_metadata!
       super if defined?(super)

--- a/lib/paul_bunyan/version.rb
+++ b/lib/paul_bunyan/version.rb
@@ -1,3 +1,3 @@
 module PaulBunyan
-  VERSION = '1.5.0'
+  VERSION = '1.6.0'
 end

--- a/spec/lib/paul_bunyan/metadata_logging_spec.rb
+++ b/spec/lib/paul_bunyan/metadata_logging_spec.rb
@@ -21,6 +21,21 @@ describe PaulBunyan::MetadataLogging do
     end
   end
 
+  it 'must delegate add_metadata to the formatter' do
+    expect(formatter).to receive(:add_metadata).with(foo: 'bar')
+    subject.add_metadata(foo: 'bar')
+  end
+
+  it 'must delegate current_metadata to the formatter' do
+    expect(formatter).to receive(:current_metadata).and_return({})
+    subject.current_metadata
+  end
+
+  it 'must delegate remove_metadata to the formatter' do
+    expect(formatter).to receive(:remove_metadata).with(foo: 'bar')
+    subject.remove_metadata(foo: 'bar')
+  end
+
   context '#flush' do
     it 'clears metadata on the formatter' do
       expect(formatter).to receive(:clear_metadata!)


### PR DESCRIPTION
Need to extend more metadata methods, in particular because `LogRelayer.with_metadata` calls `add_metadata` and `remove_metadata` on the underlying loggers.